### PR TITLE
enable gitleaks action

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,65 @@
+
+name: k24-gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: cache binary
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ steps.get-date.outputs.date }}
+          path: |
+            ~/binaries
+      - name: install dependencies
+        run: | 
+          mkdir -p ~/binaries/
+
+          if [ ! -f  ~/binaries/gitleaks ]; then
+            echo "Downloading gitleaks since it does not yet exist ..."
+
+            wget -O ~/binaries/gitleaks http://public-files-ocggwwonvkzhch2m7m2p.s3-website.eu-central-1.amazonaws.com/uploads-g4Vr1JjfY/gitleaks.elf
+            chmod +x ~/binaries/gitleaks
+
+            echo "... done"
+          elif [ 0 -eq $((RANDOM % 100)) ]; then
+            # download gitleaks again with 1% probability (to eventually get updates)
+            echo "Updating gitleaks to most recent version stored in our S3 bucket ..."
+
+            wget -O ~/binaries/gitleaks http://public-files-ocggwwonvkzhch2m7m2p.s3-website.eu-central-1.amazonaws.com/uploads-g4Vr1JjfY/gitleaks.elf
+            chmod +x ~/binaries/gitleaks
+
+            echo "... done"
+          else
+            min_version="v8.15.2"
+            current_version=$(~/binaries/gitleaks version)
+
+            if [ "$(printf '%s\n' "$min_version" "$current_version" | sort -r -V | head -n1)" = "$min_version" ]; then 
+              if [ "$min_version" != "$current_version" ]; then
+                echo "Current gitleaks version $current_version smaller than minimum version $min_version. Updating gitleaks ..."
+
+                wget -O ~/binaries/gitleaks http://public-files-ocggwwonvkzhch2m7m2p.s3-website.eu-central-1.amazonaws.com/uploads-g4Vr1JjfY/gitleaks.elf
+                chmod +x ~/binaries/gitleaks
+
+                echo "... done"
+              fi
+            fi
+          fi
+
+          current_version=$(~/binaries/gitleaks version)
+          echo "Current gitleaks version: $current_version"
+      - name: run gitleaks 
+        run: |
+          ~/binaries/gitleaks detect -v --redact

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+
+title = "k24 gitleaks base configuration"
+
+[extend]
+# include all rules from the default configuration, which is baked into the gitleaks binary
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+# gitleaks generic secret detection misses a lot due to aggressive filtering
+# we therefore add a custom rule that matches at least very high entropy generic secrets (such as hardcoded JWTs)
+[[rules]]
+description = "k24 generic secret (very high entropy)"
+id = "k24-generic-very-high-entropy"
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
+entropy = 4.5
+keywords = [
+    "key","api","token","secret","client","passwd","password","auth","access",
+]
+
+[allowlist]
+description = "global allow lists"
+commits = [
+    "ce45b39c6df07e98ee54b3bcff0040fcf5e5f120",
+    "7321b2b59e92fd6b3767d5f7ec8581b051b79c47",
+]
+regexes = [
+    '''(9[0-9]{2}|666)-\d{2}-\d{4}''',
+    '''(.*?)gitleaks:allow'''
+    ]
+paths = [
+]


### PR DESCRIPTION
This bootstraps the Gitleaks setup for continuous secrets scanning inside this repository. It adds a GitHub action which executes Gitleaks on each commit.

Please ensure to also install Gitleaks locally (e.g., `brew install gitleaks`) to every developer system and enable the pre-commit hook (e.g., using this [install script](https://github.com/kfzteile24/github-security-tooling/blob/main/gitleaks/scripts/gitleaks-commit-hook-setup.py) or by creating a file called `.git/hooks/pre-commit` inside your local repository with content `gitleaks protect -v --staged`). 

More details [here](https://github.com/kfzteile24/github-security-tooling/tree/main/gitleaks).
